### PR TITLE
[FEAT] 소셜 로그인 구현 

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8080

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8080

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc -b && vite build",
+    "dev": "vite --mode development",
+    "build": "tsc -b && vite build --mode production",
+    "build:dev": "tsc -b && vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview",
-    "lint:style": "stylelint '**/*.scss"
+    "preview": "vite preview"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/src/hooks/useSocialLogin.ts
+++ b/src/hooks/useSocialLogin.ts
@@ -1,0 +1,1 @@
+export default function useSocialLogin() {}

--- a/src/hooks/useSocialLogin.ts
+++ b/src/hooks/useSocialLogin.ts
@@ -1,1 +1,0 @@
-export default function useSocialLogin() {}

--- a/src/pages/SignIn/index.module.scss
+++ b/src/pages/SignIn/index.module.scss
@@ -1,0 +1,74 @@
+@use '../../styles/global' as *;
+
+@mixin signin-button-size {
+  width: 100%;
+  max-width: 40rem;
+  height: 6rem;
+}
+
+@mixin flex-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+@mixin flex-col-center {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.wrapper {
+  height: 100%;
+  @include flex-center;
+}
+
+.container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 5rem;
+}
+
+.service-information-container {
+  @include flex-col-center;
+  gap: 2rem;
+}
+
+.signin-container {
+  @include flex-col-center;
+  gap: 1.4rem;
+}
+
+.signin-button {
+  @include flex-center;
+  gap: 1.6rem;
+}
+
+.gooogle-signin-button {
+  background-color: #ffffff;
+  color: #767676;
+  border-radius: 10px;
+  box-shadow:
+    0 0 3px 0 rgba(0, 0, 0, 0.084),
+    0 2px 3px 0 rgba(0, 0, 0, 0.168);
+  @include signin-button-size;
+  @include font-text('heading-large');
+}
+
+.naver-signin-button {
+  background-color: #03c75a;
+  color: #ffffff;
+  border-radius: 4px;
+  @include signin-button-size;
+  @include font-text('heading-large');
+}
+
+.kakao-signin-button {
+  background-color: #fee500;
+  color: #000000;
+  border-radius: 12px;
+  @include signin-button-size;
+  @include font-text('heading-large');
+}

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -1,5 +1,36 @@
+import Text from '../../components/Text';
+import styles from './index.module.scss';
+import googleLogo from '../../assets/icon/google.svg';
+import kakaoLogo from '../../assets/icon/kakao.svg';
+import naverLogo from '../../assets/icon/naver.svg';
+import { cn } from '../../utils/cn';
+
 const SignIn = () => {
-  return <div>로그인</div>;
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.container}>
+        <header className={styles.serviceInformationContainer}>
+          <Text as="h2" font="heading-small" color="primary">
+            모임을 더 쉽게, 소중한 순간은 더 오래
+          </Text>
+          <Text as="h1" font="display-large" color="brand">
+            HEAR:WE
+          </Text>
+        </header>
+        <div className={styles.signinContainer}>
+          <button className={cn(styles.gooogleSigninButton, styles.signinButton)}>
+            <img src={googleLogo} alt=""></img>Google 로그인
+          </button>
+          <button className={cn(styles.naverSigninButton, styles.signinButton)}>
+            <img src={naverLogo} alt=""></img>네이버 로그인
+          </button>
+          <button className={cn(styles.kakaoSigninButton, styles.signinButton)}>
+            <img src={kakaoLogo} alt=""></img>카카오 로그인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default SignIn;

--- a/src/pages/SignIn/index.tsx
+++ b/src/pages/SignIn/index.tsx
@@ -6,6 +6,11 @@ import naverLogo from '../../assets/icon/naver.svg';
 import { cn } from '../../utils/cn';
 
 const SignIn = () => {
+  function handleClickSocialSignInButton(provider: 'kakao' | 'naver' | 'google') {
+    const API_URL = import.meta.env.VITE_API_URL;
+    window.location.href = `${API_URL}/oauth2/authorization/${provider}`;
+  }
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.container}>
@@ -18,13 +23,22 @@ const SignIn = () => {
           </Text>
         </header>
         <div className={styles.signinContainer}>
-          <button className={cn(styles.gooogleSigninButton, styles.signinButton)}>
+          <button
+            onClick={() => handleClickSocialSignInButton('google')}
+            className={cn(styles.gooogleSigninButton, styles.signinButton)}
+          >
             <img src={googleLogo} alt=""></img>Google 로그인
           </button>
-          <button className={cn(styles.naverSigninButton, styles.signinButton)}>
+          <button
+            onClick={() => handleClickSocialSignInButton('naver')}
+            className={cn(styles.naverSigninButton, styles.signinButton)}
+          >
             <img src={naverLogo} alt=""></img>네이버 로그인
           </button>
-          <button className={cn(styles.kakaoSigninButton, styles.signinButton)}>
+          <button
+            onClick={() => handleClickSocialSignInButton('kakao')}
+            className={cn(styles.kakaoSigninButton, styles.signinButton)}
+          >
             <img src={kakaoLogo} alt=""></img>카카오 로그인
           </button>
         </div>


### PR DESCRIPTION
## 📂 작업 내용

closes #3 

- [x] 소셜 로그인 화면 구현
- [x] 구글 소셜 로그인 기능 구현
- [x] 네이버 소셜 로그인 기능 구현
- [x] 카카오 소셜 로그인 기능 구현

## 💡 자세한 설명

### 환경 변수 설정

- 개발 환경과 배포 환경일 때의 환경 변수 설정
- 빌드 명령 또는 개발 환경 실행 명령에 따라 환경 변수가 다르게 적용되도록 설정 

### SignIn 페이지 화면 구현

- 구글 소셜 로그인, 네이버 소셜 로그인, 카카오 소셜 로그인 버튼 가이드에 따라 버튼 구현
- 소셜 로그인 버튼의 경우 가이드를 지키는 것이 우선순위라고 생각되어 Button 공통 컴포넌트를 적용하지 않고 스타일을 따로 적용함 

### SignIn 로직 구현

- 구글, 네이버, 카카오 소셜 로그인 버튼 클릭 시 해당 URL로 이동하도록 구현  

## 📗 참고 자료 & 구현 결과 (선택)

![2](https://github.com/user-attachments/assets/d51f921c-7578-4ecd-8dc4-255f6e83d5d9)


## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? 
- [x] 이슈는 close 했나요?
- [ ] Reviewers, Labels를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?